### PR TITLE
Fix PWA caching issue by removing service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
     "react/": "https://esm.sh/react@^19.1.1/",
     "vite": "https://esm.sh/vite@^7.1.2",
     "@vitejs/plugin-react": "https://esm.sh/@vitejs/plugin-react@^5.0.0",
-    "vite-plugin-pwa": "https://esm.sh/vite-plugin-pwa@^1.0.2",
     "jspdf": "https://esm.sh/jspdf@^3.0.1",
     "jspdf-autotable": "https://esm.sh/jspdf-autotable@^5.0.2"
   }
@@ -29,6 +28,12 @@
   <body class="bg-slate-900">
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>
-  <script type="module" src="/index.tsx"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/service-worker.js');
+      });
+    }
+  </script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,3 +1,16 @@
-// THIS FILE IS DECOMMISSIONED.
-// The service worker has been removed to prevent aggressive caching issues.
-// The application will now operate in an online-only mode.
+self.addEventListener('install', () => {
+  // Activate new service worker as soon as it's installed
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', () => {
+  // Unregister the service worker
+  self.registration.unregister()
+    .then(() => {
+      // Reload all clients to ensure they get the latest version of the site
+      return self.clients.matchAll();
+    })
+    .then(clients => {
+      clients.forEach(client => client.navigate(client.url));
+    });
+});


### PR DESCRIPTION
The PWA was aggressively caching assets, preventing new versions of the site from loading for users. This was caused by a `vite-plugin-pwa` that was included via an import map in `index.html`.

This change resolves the issue by:
1. Replacing the existing service worker with a new one that unregisters itself upon activation. This will remove the old service worker from users' browsers.
2. Removing `vite-plugin-pwa` from the `importmap` in `index.html` to prevent a new service worker from being generated.
3. Adding a script to `index.html` to register the new self-unregistering service worker.
4. Removing a duplicate and unnecessary script tag from `index.html`.