### PR TITLE
feat: Add Gantt Chart to Dashboard

### DIFF
--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -1,0 +1,83 @@
+import React, { useMemo } from 'react';
+import { Subject } from '../types';
+
+interface CalendarViewProps {
+  subjects: Subject[];
+}
+
+const CalendarView: React.FC<CalendarViewProps> = ({ subjects }) => {
+  const currentDate = new Date();
+
+  const { month, year, firstDayOfMonth, daysInMonth } = useMemo(() => {
+    const month = currentDate.getMonth();
+    const year = currentDate.getFullYear();
+    const firstDayOfMonth = new Date(year, month, 1).getDay();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    return { month, year, firstDayOfMonth, daysInMonth };
+  }, [currentDate]);
+
+  const monthName = currentDate.toLocaleString('default', { month: 'long' });
+  const dayHeaders = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+  const lectureDates = useMemo(() => {
+    const dates = new Set<string>();
+    subjects.forEach(subject => {
+      subject.chapters.forEach(chapter => {
+        chapter.lectures.forEach(lecture => {
+          if (lecture.date) {
+            dates.add(lecture.date);
+          }
+        });
+      });
+    });
+    return dates;
+  }, [subjects]);
+
+  const calendarDays = useMemo(() => {
+    const blanks = Array(firstDayOfMonth).fill(null);
+    const days = Array.from({ length: daysInMonth }, (_, i) => i + 1);
+    return [...blanks, ...days];
+  }, [firstDayOfMonth, daysInMonth]);
+
+  return (
+    <div className="bg-slate-800 p-6 rounded-xl shadow-lg border border-slate-700/50">
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="text-xl font-semibold text-slate-100">{`${monthName} ${year}`}</h3>
+        {/* TODO: Add next/prev month controls */}
+      </div>
+      <div className="grid grid-cols-7 gap-2 text-center">
+        {dayHeaders.map(day => (
+          <div key={day} className="font-semibold text-xs text-slate-400 uppercase">{day}</div>
+        ))}
+        {calendarDays.map((day, index) => {
+          if (day === null) {
+            return <div key={index} className="h-10 w-10" />;
+          }
+
+          const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+          const hasLecture = lectureDates.has(dateStr);
+
+          const today = new Date();
+          const isToday = day === today.getDate() && month === today.getMonth() && year === today.getFullYear();
+
+          return (
+            <div
+              key={index}
+              className={`relative flex items-center justify-center h-10 w-10 rounded-full text-sm transition-colors ${
+                isToday ? 'bg-indigo-600 text-white font-bold' : 'text-slate-200'
+              }`}
+              title={hasLecture ? 'Lecture Day' : ''}
+            >
+              {day}
+              {hasLecture && (
+                <div className="absolute bottom-1.5 h-1.5 w-1.5 bg-cyan-400 rounded-full"></div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default CalendarView;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -3,6 +3,8 @@ import { Subject, LectureStatus } from '../types';
 import ProgressiveBar from './ProgressiveBar';
 import ProgressChart from './ProgressChart';
 import ActivityChart from './ActivityChart';
+import CalendarView from './CalendarView';
+import GanttChartView from './GanttChartView';
 
 interface DashboardProps {
   subjects: Subject[];
@@ -89,6 +91,14 @@ const Dashboard: React.FC<DashboardProps> = ({ subjects }) => {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
         <ProgressChart subjects={subjects} />
         <ActivityChart subjects={subjects} />
+      </div>
+
+      <div className="mb-8">
+        <CalendarView subjects={subjects} />
+      </div>
+
+      <div className="mb-8">
+        <GanttChartView subjects={subjects} />
       </div>
       
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-6">

--- a/src/components/GanttChartView.tsx
+++ b/src/components/GanttChartView.tsx
@@ -1,0 +1,103 @@
+import React, { useMemo } from 'react';
+import { Subject } from '../types';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+
+interface GanttChartViewProps {
+  subjects: Subject[];
+}
+
+const GanttChartView: React.FC<GanttChartViewProps> = ({ subjects }) => {
+  const ganttData = useMemo(() => {
+    const allLecturesWithDates = subjects
+      .flatMap(s => s.chapters.flatMap(c => c.lectures))
+      .filter(l => l.date)
+      .map(l => ({ ...l, dateObj: new Date(l.date) }));
+
+    if (allLecturesWithDates.length === 0) {
+      return { chartData: [], projectStartDate: null };
+    }
+
+    const projectStartDate = new Date(Math.min(...allLecturesWithDates.map(l => l.dateObj.getTime())));
+    projectStartDate.setHours(0, 0, 0, 0);
+
+    const chartData = subjects
+      .map(subject => {
+        const subjectLectures = subject.chapters
+          .flatMap(c => c.lectures)
+          .filter(l => l.date)
+          .map(l => new Date(l.date));
+
+        if (subjectLectures.length === 0) return null;
+
+        const subjectStartDate = new Date(Math.min(...subjectLectures.map(d => d.getTime())));
+        const subjectEndDate = new Date(Math.max(...subjectLectures.map(d => d.getTime())));
+        subjectStartDate.setHours(0, 0, 0, 0);
+        subjectEndDate.setHours(0, 0, 0, 0);
+
+        const dayInMillis = 1000 * 60 * 60 * 24;
+        const spacer = Math.floor((subjectStartDate.getTime() - projectStartDate.getTime()) / dayInMillis);
+        const duration = Math.floor((subjectEndDate.getTime() - subjectStartDate.getTime()) / dayInMillis) + 1;
+
+        return {
+          name: subject.name,
+          spacer,
+          duration,
+          startDateStr: subjectStartDate.toLocaleDateString(),
+          endDateStr: subjectEndDate.toLocaleDateString(),
+        };
+      })
+      .filter((d): d is NonNullable<typeof d> => d !== null);
+
+    return { chartData, projectStartDate };
+  }, [subjects]);
+
+  if (ganttData.chartData.length === 0) {
+    return null; // Don't render anything if there's no data to show
+  }
+
+  const CustomTooltip = ({ active, payload, label }: any) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <div className="bg-slate-900/80 p-3 rounded-md border border-slate-700 text-sm shadow-lg backdrop-blur-sm">
+          <p className="font-bold text-slate-100">{label}</p>
+          <p className="text-slate-300">
+            Duration: <span className="font-semibold text-white">{data.duration} days</span>
+          </p>
+          <p className="text-slate-400 text-xs mt-1">
+            {data.startDateStr} - {data.endDateStr}
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div className="bg-slate-800 p-6 rounded-xl shadow-lg border border-slate-700/50">
+      <h3 className="text-xl font-semibold text-slate-100 mb-4">Subject Timelines</h3>
+      <div style={{ width: '100%', height: ganttData.chartData.length * 50 + 30 }}>
+        <ResponsiveContainer>
+          <BarChart
+            data={ganttData.chartData}
+            layout="vertical"
+            margin={{ top: 5, right: 20, left: 20, bottom: 5 }}
+            barCategoryGap="35%"
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#374151" horizontal={false} />
+            <XAxis type="number" stroke="#9ca3af" tick={{ fontSize: 12 }} domain={['dataMin', 'dataMax + 5']} />
+            <YAxis type="category" dataKey="name" stroke="#9ca3af" width={80} tick={{ fontSize: 12 }} />
+            <Tooltip
+              cursor={{ fill: 'rgba(71, 85, 105, 0.3)' }}
+              content={<CustomTooltip />}
+            />
+            <Bar dataKey="spacer" stackId="a" fill="transparent" />
+            <Bar dataKey="duration" stackId="a" fill="#22d3ee" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default GanttChartView;

--- a/src/components/modals/AddOrEditLectureModal.tsx
+++ b/src/components/modals/AddOrEditLectureModal.tsx
@@ -62,7 +62,7 @@ const AddOrEditLectureModal: React.FC<AddOrEditLectureModalProps> = ({ onClose, 
     <Modal title={isEditMode ? 'Edit Lecture Details' : 'Add Lecture(s)'} onClose={onClose} size="lg">
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label htmlFor="name" className="block text-sm font-medium text-text-secondary-light dark:text-text-secondary-dark mb-1">Lecture Name {bulkCount > 1 && '(Prefix)'}</label>
+          <label htmlFor="name" className="block text-sm font-medium text-text-secondary-light dark:text-text-secondary-dark mb-1">Lecture Name {Number(bulkCount) > 1 && '(Prefix)'}</label>
           <input id="name" name="name" type="text" value={formData.name} onChange={handleChange} className="w-full bg-primary-light dark:bg-primary-dark border border-border-color rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-accent-light dark:focus:ring-accent-dark" autoFocus />
         </div>
 
@@ -109,7 +109,7 @@ const AddOrEditLectureModal: React.FC<AddOrEditLectureModalProps> = ({ onClose, 
         <div className="flex justify-end space-x-3 pt-4">
           <button type="button" onClick={onClose} className="px-4 py-2 rounded-md bg-secondary-light dark:bg-secondary-dark hover:bg-primary-light dark:hover:bg-primary-dark transition-colors border border-border-color">Cancel</button>
           <button type="submit" className="px-4 py-2 rounded-md bg-accent-light dark:bg-accent-dark hover:opacity-90 text-white transition-colors font-semibold">
-            {isEditMode ? 'Save Changes' : `Add ${bulkCount > 1 ? `${bulkCount} Lectures` : 'Lecture'}`}
+            {isEditMode ? 'Save Changes' : `Add ${Number(bulkCount) > 1 ? `${bulkCount} Lectures` : 'Lecture'}`}
           </button>
         </div>
       </form>


### PR DESCRIPTION
- Creates a new `GanttChartView` component to visualize subject timelines.
- The component uses a stacked BarChart from `recharts` to simulate a Gantt chart, showing the duration of each subject based on its earliest and latest lecture dates.
- Implements a custom tooltip to show detailed date ranges and duration for each subject.
- Integrates the new chart into the main Dashboard.
- Resolves merge conflict by ensuring the `Dashboard.tsx` file contains both the new Gantt Chart and the previously added Calendar View.